### PR TITLE
Fixes IE8 not letting you get the imports on some style sheets

### DIFF
--- a/add-on/src/main/java/com/vaadin/addon/responsive/client/ResponsiveConnector.java
+++ b/add-on/src/main/java/com/vaadin/addon/responsive/client/ResponsiveConnector.java
@@ -114,14 +114,8 @@ public class ResponsiveConnector extends AbstractExtensionConnector implements
 	
 	// Loop all stylesheets on the page and process them individually
 	for(var i = 0, len = sheets.length; i < len; i++) {
-	    try {
-                var sheet = sheets[i];
-                @com.vaadin.addon.responsive.client.ResponsiveConnector::searchStylesheetForBreakPoints(Lcom/google/gwt/core/client/JavaScriptObject;)(sheet);
-            } catch(e) {
-                // This is added due to IE8 failing to handle some sheets for unknown reason (throws a permission denied exception)
-                console.log("Failed to parse CSS style sheet: " + sheet.href); 
-                // Just continue parsing the other sheets
-            }        
+            var sheet = sheets[i];
+            @com.vaadin.addon.responsive.client.ResponsiveConnector::searchStylesheetForBreakPoints(Lcom/google/gwt/core/client/JavaScriptObject;)(sheet);
 	}
 	
 	// Only for debugging
@@ -157,10 +151,16 @@ public class ResponsiveConnector extends AbstractExtensionConnector implements
 	}
 
         // Special import handling for IE8
-        if (IE8) {
-            for(var i = 0, len = sheet.imports.length; i < len; i++) {
-                @com.vaadin.addon.responsive.client.ResponsiveConnector::searchStylesheetForBreakPoints(Lcom/google/gwt/core/client/JavaScriptObject;)(sheet.imports[i]);
+        try {
+            if (IE8) {
+                for(var i = 0, len = sheet.imports.length; i < len; i++) {
+                    @com.vaadin.addon.responsive.client.ResponsiveConnector::searchStylesheetForBreakPoints(Lcom/google/gwt/core/client/JavaScriptObject;)(sheet.imports[i]);
+                }
             }
+        } catch(e) {
+            // This is added due to IE8 failing to handle imports of some sheets for unknown reason (throws a permission denied exception)
+            console.log("Failed to handle imports of CSS style sheet: " + sheet.href); 
+            // Just continue parsing the other sheets
         }
     
 	// Loop through the rulesets


### PR DESCRIPTION
For some reason, IE8 seems to throw a 'Permission denied' exception when trying to access the imports of some style sheets. For me this only happens on style sheets which are included into document header from add-ons by gwt.

I could not understand why you aren't permitted to access the imports of these style sheets while all the others work - they're loaded from the same server anyway.

The fix adds exception handling and logging for the IE8-specific import handling, allowing the process to continue even if such a style sheet is encountered.
